### PR TITLE
fix: rules without attach metadata are falls back to manual

### DIFF
--- a/internal/bridge/cursor.go
+++ b/internal/bridge/cursor.go
@@ -1,7 +1,6 @@
 package bridge
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -78,7 +77,16 @@ func (bridge *CursorBridge) ToAgentRule(rule domain.RuleItem) (CursorRule, error
 		}, nil
 	}
 
-	return CursorRule{}, fmt.Errorf("unsupported rule attach type: %s", rule.Metadata.Attach)
+	// Fallback as manual rule.
+	return CursorRule{
+		Slug:    rule.Slug,
+		Content: rule.Content,
+		Metadata: CursorRuleMetadata{
+			AlwaysApply: false,
+			Description: "",
+			Globs:       "",
+		},
+	}, nil
 }
 
 func (bridge *CursorBridge) FromAgentRule(rule CursorRule) (domain.RuleItem, error) {

--- a/internal/bridge/cursor_test.go
+++ b/internal/bridge/cursor_test.go
@@ -61,6 +61,44 @@ func TestCursorBridge_RuleConversion(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "manual attach type",
+			domainRule: *domain.NewRuleItem(
+				"manual",
+				"content",
+				domain.RuleMetadata{
+					Attach: domain.AttachTypeManual,
+				},
+			),
+			expectedRule: bridge.CursorRule{
+				Slug:    "manual",
+				Content: "content",
+				Metadata: bridge.CursorRuleMetadata{
+					AlwaysApply: false,
+					Description: "",
+					Globs:       "",
+				},
+			},
+		},
+		{
+			name: "unsupported attach type falls back to manual",
+			domainRule: *domain.NewRuleItem(
+				"unsupported",
+				"content",
+				domain.RuleMetadata{
+					Attach: "unsupported",
+				},
+			),
+			expectedRule: bridge.CursorRule{
+				Slug:    "unsupported",
+				Content: "content",
+				Metadata: bridge.CursorRuleMetadata{
+					AlwaysApply: false,
+					Description: "",
+					Globs:       "",
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/bridge/github-copilot.go
+++ b/internal/bridge/github-copilot.go
@@ -1,7 +1,6 @@
 package bridge
 
 import (
-	"fmt"
 	"strings"
 
 	yaml "github.com/goccy/go-yaml"
@@ -91,7 +90,12 @@ func (bridge *GitHubCopilotBridge) ToAgentRule(rule domain.RuleItem) (GitHubCopi
 		}, nil
 	}
 
-	return GitHubCopilotInstruction{}, fmt.Errorf("unsupported rule attach type: %s", rule.Metadata.Attach)
+	// Fallback as manual rule.
+	return GitHubCopilotInstruction{
+		Slug:     rule.Slug,
+		Content:  rule.Content,
+		Metadata: GitHubCopilotInstructionMetadata{},
+	}, nil
 }
 
 func (bridge *GitHubCopilotBridge) FromAgentRule(rule GitHubCopilotInstruction) (domain.RuleItem, error) {

--- a/internal/bridge/github-copilot_test.go
+++ b/internal/bridge/github-copilot_test.go
@@ -91,17 +91,36 @@ func TestVSCodeGitHubCopilotBridge_ToAgentRule(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name: "UnsupportedAttachType",
+			name: "manual attach type",
 			ruleItem: *domain.NewRuleItem(
-				"test-unsupported",
-				"# Test Unsupported\n\nThis rule has unsupported attach type.",
+				"manual",
+				"content",
 				domain.RuleMetadata{
-					Attach: "unsupported",
-					Globs:  []string{},
+					Attach: domain.AttachTypeManual,
 				},
 			),
-			expected:  bridge.GitHubCopilotInstruction{},
-			expectErr: true,
+			expected: bridge.GitHubCopilotInstruction{
+				Slug:     "manual",
+				Content:  "content",
+				Metadata: bridge.GitHubCopilotInstructionMetadata{},
+			},
+			expectErr: false,
+		},
+		{
+			name: "unsupported attach type falls back to manual",
+			ruleItem: *domain.NewRuleItem(
+				"unsupported",
+				"content",
+				domain.RuleMetadata{
+					Attach: "unsupported",
+				},
+			),
+			expected: bridge.GitHubCopilotInstruction{
+				Slug:     "unsupported",
+				Content:  "content",
+				Metadata: bridge.GitHubCopilotInstructionMetadata{},
+			},
+			expectErr: false,
 		},
 	}
 

--- a/internal/bridge/windsurf.go
+++ b/internal/bridge/windsurf.go
@@ -86,7 +86,17 @@ func (bridge *WindsurfBridge) ToAgentRule(rule domain.RuleItem) (WindsurfRule, e
 			},
 		}, nil
 	}
-	return WindsurfRule{}, fmt.Errorf("unsupported rule attach type: %s", rule.Metadata.Attach)
+
+	// Fallback as manual rule.
+	return WindsurfRule{
+		Slug:    rule.Slug,
+		Content: rule.Content,
+		Metadata: WindsurfRuleMetadata{
+			Trigger:     WindsurfTriggerTypeManual,
+			Globs:       "",
+			Description: "",
+		},
+	}, nil
 }
 
 func (bridge *WindsurfBridge) FromAgentRule(rule WindsurfRule) (domain.RuleItem, error) {

--- a/internal/bridge/windsurf_test.go
+++ b/internal/bridge/windsurf_test.go
@@ -236,6 +236,25 @@ func TestWindsurfBridge_ToAgentRule(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "unsupported attach type falls back to manual",
+			domainRule: *domain.NewRuleItem(
+				"unsupported",
+				"content",
+				domain.RuleMetadata{
+					Attach: "unsupported",
+				},
+			),
+			expectedRule: bridge.WindsurfRule{
+				Slug:    "unsupported",
+				Content: "content",
+				Metadata: bridge.WindsurfRuleMetadata{
+					Trigger:     bridge.WindsurfTriggerTypeManual,
+					Globs:       "",
+					Description: "",
+				},
+			},
+		},
 	}
 
 	bridge := bridge.NewWindsurfBridge()


### PR DESCRIPTION
closes #49 

Enables importing existing documents without changing the frontmatter.
For rule files that do not have an attach property, rules will be treated as manual attached rule.