### PR TITLE
refactor: remove logging-only parameters and implement URI-based resource identification

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ Each integration defines:
 
 **Generated file structure**:
 
-```
+```text
 .cursor/rules/ajisai/package-name/preset-name/rule-slug.mdc
 .cursor/prompts/ajisai/package-name/preset-name/prompt-slug.md
 ```

--- a/internal/bridge/cursor.go
+++ b/internal/bridge/cursor.go
@@ -92,11 +92,18 @@ func (bridge *CursorBridge) ToAgentRule(rule domain.RuleItem) (CursorRule, error
 func (bridge *CursorBridge) FromAgentRule(rule CursorRule) (domain.RuleItem, error) {
 	emptyGlobs := make([]string, 0)
 
+	// Create URI with placeholder values since bridge doesn't have package/preset context
+	uri := domain.URI{
+		Scheme:  domain.Scheme,
+		Package: "", // placeholder, bridge doesn't have this context
+		Preset:  "", // placeholder, bridge doesn't have this context
+		Type:    domain.RulesPresetType,
+		Path:    rule.Slug,
+	}
+
 	if rule.Metadata.AlwaysApply {
 		return *domain.NewRuleItem(
-			"", // packageName - placeholder, bridge doesn't have this context
-			"", // presetName - placeholder, bridge doesn't have this context
-			rule.Slug,
+			uri,
 			rule.Content,
 			domain.RuleMetadata{
 				Attach:      domain.AttachTypeAlways,
@@ -108,9 +115,7 @@ func (bridge *CursorBridge) FromAgentRule(rule CursorRule) (domain.RuleItem, err
 
 	if rule.Metadata.Globs != "" {
 		return *domain.NewRuleItem(
-			"", // packageName - placeholder, bridge doesn't have this context
-			"", // presetName - placeholder, bridge doesn't have this context
-			rule.Slug,
+			uri,
 			rule.Content,
 			domain.RuleMetadata{
 				Attach:      domain.AttachTypeGlob,
@@ -122,9 +127,7 @@ func (bridge *CursorBridge) FromAgentRule(rule CursorRule) (domain.RuleItem, err
 
 	if rule.Metadata.Description != "" {
 		return *domain.NewRuleItem(
-			"", // packageName - placeholder, bridge doesn't have this context
-			"", // presetName - placeholder, bridge doesn't have this context
-			rule.Slug,
+			uri,
 			rule.Content,
 			domain.RuleMetadata{
 				Attach:      domain.AttachTypeAgentRequested,
@@ -135,9 +138,7 @@ func (bridge *CursorBridge) FromAgentRule(rule CursorRule) (domain.RuleItem, err
 	}
 
 	return *domain.NewRuleItem(
-		"", // packageName - placeholder, bridge doesn't have this context
-		"", // presetName - placeholder, bridge doesn't have this context
-		rule.Slug,
+		uri,
 		rule.Content,
 		domain.RuleMetadata{
 			Attach:      domain.AttachTypeManual,
@@ -155,10 +156,17 @@ func (bridge *CursorBridge) ToAgentPrompt(prompt domain.PromptItem) (CursorPromp
 }
 
 func (bridge *CursorBridge) FromAgentPrompt(prompt CursorPrompt) (domain.PromptItem, error) {
+	// Create URI with placeholder values since bridge doesn't have package/preset context
+	uri := domain.URI{
+		Scheme:  domain.Scheme,
+		Package: "", // placeholder, bridge doesn't have this context
+		Preset:  "", // placeholder, bridge doesn't have this context
+		Type:    domain.PromptsPresetType,
+		Path:    prompt.Slug,
+	}
+
 	return *domain.NewPromptItem(
-		"", // packageName - placeholder, bridge doesn't have this context
-		"", // presetName - placeholder, bridge doesn't have this context
-		prompt.Slug,
+		uri,
 		prompt.Content,
 		domain.PromptMetadata{},
 	), nil

--- a/internal/bridge/cursor.go
+++ b/internal/bridge/cursor.go
@@ -92,14 +92,8 @@ func (bridge *CursorBridge) ToAgentRule(rule domain.RuleItem) (CursorRule, error
 func (bridge *CursorBridge) FromAgentRule(rule CursorRule) (domain.RuleItem, error) {
 	emptyGlobs := make([]string, 0)
 
-	// Create URI with placeholder values since bridge doesn't have package/preset context
-	uri := domain.URI{
-		Scheme:  domain.Scheme,
-		Package: "", // placeholder, bridge doesn't have this context
-		Preset:  "", // placeholder, bridge doesn't have this context
-		Type:    domain.RulesPresetType,
-		Path:    rule.Slug,
-	}
+	// Create URI using the domain.NewPlaceholderURI helper
+	uri := domain.NewPlaceholderURI(rule.Slug, domain.RulesPresetType)
 
 	if rule.Metadata.AlwaysApply {
 		return *domain.NewRuleItem(
@@ -156,14 +150,8 @@ func (bridge *CursorBridge) ToAgentPrompt(prompt domain.PromptItem) (CursorPromp
 }
 
 func (bridge *CursorBridge) FromAgentPrompt(prompt CursorPrompt) (domain.PromptItem, error) {
-	// Create URI with placeholder values since bridge doesn't have package/preset context
-	uri := domain.URI{
-		Scheme:  domain.Scheme,
-		Package: "", // placeholder, bridge doesn't have this context
-		Preset:  "", // placeholder, bridge doesn't have this context
-		Type:    domain.PromptsPresetType,
-		Path:    prompt.Slug,
-	}
+	// Create URI using the domain.NewPlaceholderURI helper
+	uri := domain.NewPlaceholderURI(prompt.Slug, domain.PromptsPresetType)
 
 	return *domain.NewPromptItem(
 		uri,

--- a/internal/bridge/cursor_test.go
+++ b/internal/bridge/cursor_test.go
@@ -23,8 +23,14 @@ func TestCursorBridge_RuleConversion(t *testing.T) {
 	}{
 		{
 			name: "AlwaysAttach rule",
-			domainRule: *domain.NewRuleItem("test-package", "test-preset",
-				"always-rule",
+			domainRule: *domain.NewRuleItem(
+				domain.URI{
+					Scheme:  domain.Scheme,
+					Package: "test-package",
+					Preset:  "test-preset",
+					Type:    domain.RulesPresetType,
+					Path:    "always-rule",
+				},
 				"This is an always rule",
 				domain.RuleMetadata{
 					Attach: domain.AttachTypeAlways,
@@ -43,8 +49,14 @@ func TestCursorBridge_RuleConversion(t *testing.T) {
 		},
 		{
 			name: "Glob rule",
-			domainRule: *domain.NewRuleItem("test-package", "test-preset",
-				"glob-rule",
+			domainRule: *domain.NewRuleItem(
+				domain.URI{
+					Scheme:  domain.Scheme,
+					Package: "test-package",
+					Preset:  "test-preset",
+					Type:    domain.RulesPresetType,
+					Path:    "glob-rule",
+				},
 				"This is a glob rule",
 				domain.RuleMetadata{
 					Attach: domain.AttachTypeGlob,
@@ -63,8 +75,14 @@ func TestCursorBridge_RuleConversion(t *testing.T) {
 		},
 		{
 			name: "manual attach type",
-			domainRule: *domain.NewRuleItem("test-package", "test-preset",
-				"manual",
+			domainRule: *domain.NewRuleItem(
+				domain.URI{
+					Scheme:  domain.Scheme,
+					Package: "test-package",
+					Preset:  "test-preset",
+					Type:    domain.RulesPresetType,
+					Path:    "manual",
+				},
 				"content",
 				domain.RuleMetadata{
 					Attach: domain.AttachTypeManual,
@@ -82,8 +100,14 @@ func TestCursorBridge_RuleConversion(t *testing.T) {
 		},
 		{
 			name: "unsupported attach type falls back to manual",
-			domainRule: *domain.NewRuleItem("test-package", "test-preset",
-				"unsupported",
+			domainRule: *domain.NewRuleItem(
+				domain.URI{
+					Scheme:  domain.Scheme,
+					Package: "test-package",
+					Preset:  "test-preset",
+					Type:    domain.RulesPresetType,
+					Path:    "unsupported",
+				},
 				"content",
 				domain.RuleMetadata{
 					Attach: "unsupported",
@@ -131,8 +155,14 @@ func TestCursorBridge_RuleConversion(t *testing.T) {
 					Globs:       "",
 				},
 			},
-			expectedRule: *domain.NewRuleItem("", "", // bridge doesn't have package/preset context
-				"always-rule",
+			expectedRule: *domain.NewRuleItem(
+				domain.URI{
+					Scheme:  domain.Scheme,
+					Package: "", // bridge doesn't have package/preset context
+					Preset:  "", // bridge doesn't have package/preset context
+					Type:    domain.RulesPresetType,
+					Path:    "always-rule",
+				},
 				"This is an always rule",
 				domain.RuleMetadata{
 					Attach:      domain.AttachTypeAlways,
@@ -152,8 +182,14 @@ func TestCursorBridge_RuleConversion(t *testing.T) {
 					Globs:       "*.go,*.md",
 				},
 			},
-			expectedRule: *domain.NewRuleItem("", "", // bridge doesn't have package/preset context
-				"glob-rule",
+			expectedRule: *domain.NewRuleItem(
+				domain.URI{
+					Scheme:  domain.Scheme,
+					Package: "", // bridge doesn't have package/preset context
+					Preset:  "", // bridge doesn't have package/preset context
+					Type:    domain.RulesPresetType,
+					Path:    "glob-rule",
+				},
 				"This is a glob rule",
 				domain.RuleMetadata{
 					Attach:      domain.AttachTypeGlob,
@@ -181,8 +217,14 @@ func TestCursorBridge_PromptConversion(t *testing.T) {
 	bridgeInstance := bridge.NewCursorBridge()
 
 	// Test ToAgentPrompt
-	domainPrompt := *domain.NewPromptItem("test-package", "test-preset",
-		"test-prompt",
+	domainPrompt := *domain.NewPromptItem(
+		domain.URI{
+			Scheme:  domain.Scheme,
+			Package: "test-package",
+			Preset:  "test-preset",
+			Type:    domain.PromptsPresetType,
+			Path:    "test-prompt",
+		},
 		"This is a test prompt.",
 		domain.PromptMetadata{},
 	)
@@ -198,8 +240,14 @@ func TestCursorBridge_PromptConversion(t *testing.T) {
 		Content: "This is a Cursor prompt.",
 	}
 
-	expectedDomainPrompt := *domain.NewPromptItem("", "", // bridge doesn't have package/preset context
-		"cursor-prompt",
+	expectedDomainPrompt := *domain.NewPromptItem(
+		domain.URI{
+			Scheme:  domain.Scheme,
+			Package: "", // bridge doesn't have package/preset context
+			Preset:  "", // bridge doesn't have package/preset context
+			Type:    domain.PromptsPresetType,
+			Path:    "cursor-prompt",
+		},
 		"This is a Cursor prompt.",
 		domain.PromptMetadata{},
 	)

--- a/internal/bridge/github-copilot.go
+++ b/internal/bridge/github-copilot.go
@@ -101,14 +101,8 @@ func (bridge *GitHubCopilotBridge) ToAgentRule(rule domain.RuleItem) (GitHubCopi
 func (bridge *GitHubCopilotBridge) FromAgentRule(rule GitHubCopilotInstruction) (domain.RuleItem, error) {
 	emptyGlobs := make([]string, 0)
 
-	// Create URI with placeholder values since bridge doesn't have package/preset context
-	uri := domain.URI{
-		Scheme:  domain.Scheme,
-		Package: "", // placeholder, bridge doesn't have this context
-		Preset:  "", // placeholder, bridge doesn't have this context
-		Type:    domain.RulesPresetType,
-		Path:    rule.Slug,
-	}
+	// Create URI using the domain.NewPlaceholderURI helper
+	uri := domain.NewPlaceholderURI(rule.Slug, domain.RulesPresetType)
 
 	globs := utils.RemoveZeroValues(strings.Split(rule.Metadata.ApplyTo, ","))
 	alwaysApplied := utils.ContainsAny(globs, GitHubCopilotInstructionApplyToAll)
@@ -159,14 +153,8 @@ func (bridge *GitHubCopilotBridge) ToAgentPrompt(prompt domain.PromptItem) (GitH
 }
 
 func (bridge *GitHubCopilotBridge) FromAgentPrompt(prompt GitHubCopilotPrompt) (domain.PromptItem, error) {
-	// Create URI with placeholder values since bridge doesn't have package/preset context
-	uri := domain.URI{
-		Scheme:  domain.Scheme,
-		Package: "", // placeholder, bridge doesn't have this context
-		Preset:  "", // placeholder, bridge doesn't have this context
-		Type:    domain.PromptsPresetType,
-		Path:    prompt.Slug,
-	}
+	// Create URI using the domain.NewPlaceholderURI helper
+	uri := domain.NewPlaceholderURI(prompt.Slug, domain.PromptsPresetType)
 
 	return *domain.NewPromptItem(
 		uri,

--- a/internal/bridge/github-copilot.go
+++ b/internal/bridge/github-copilot.go
@@ -101,14 +101,21 @@ func (bridge *GitHubCopilotBridge) ToAgentRule(rule domain.RuleItem) (GitHubCopi
 func (bridge *GitHubCopilotBridge) FromAgentRule(rule GitHubCopilotInstruction) (domain.RuleItem, error) {
 	emptyGlobs := make([]string, 0)
 
+	// Create URI with placeholder values since bridge doesn't have package/preset context
+	uri := domain.URI{
+		Scheme:  domain.Scheme,
+		Package: "", // placeholder, bridge doesn't have this context
+		Preset:  "", // placeholder, bridge doesn't have this context
+		Type:    domain.RulesPresetType,
+		Path:    rule.Slug,
+	}
+
 	globs := utils.RemoveZeroValues(strings.Split(rule.Metadata.ApplyTo, ","))
 	alwaysApplied := utils.ContainsAny(globs, GitHubCopilotInstructionApplyToAll)
 
 	if alwaysApplied {
 		return *domain.NewRuleItem(
-			"", // packageName - placeholder, bridge doesn't have this context
-			"", // presetName - placeholder, bridge doesn't have this context
-			rule.Slug,
+			uri,
 			rule.Content,
 			domain.RuleMetadata{
 				Attach: domain.AttachTypeAlways,
@@ -119,9 +126,7 @@ func (bridge *GitHubCopilotBridge) FromAgentRule(rule GitHubCopilotInstruction) 
 
 	if len(globs) > 0 {
 		return *domain.NewRuleItem(
-			"", // packageName - placeholder, bridge doesn't have this context
-			"", // presetName - placeholder, bridge doesn't have this context
-			rule.Slug,
+			uri,
 			rule.Content,
 			domain.RuleMetadata{
 				Attach: domain.AttachTypeGlob,
@@ -131,9 +136,7 @@ func (bridge *GitHubCopilotBridge) FromAgentRule(rule GitHubCopilotInstruction) 
 	}
 
 	return *domain.NewRuleItem(
-		"", // packageName - placeholder, bridge doesn't have this context
-		"", // presetName - placeholder, bridge doesn't have this context
-		rule.Slug,
+		uri,
 		rule.Content,
 		domain.RuleMetadata{
 			Attach: domain.AttachTypeManual,
@@ -156,10 +159,17 @@ func (bridge *GitHubCopilotBridge) ToAgentPrompt(prompt domain.PromptItem) (GitH
 }
 
 func (bridge *GitHubCopilotBridge) FromAgentPrompt(prompt GitHubCopilotPrompt) (domain.PromptItem, error) {
+	// Create URI with placeholder values since bridge doesn't have package/preset context
+	uri := domain.URI{
+		Scheme:  domain.Scheme,
+		Package: "", // placeholder, bridge doesn't have this context
+		Preset:  "", // placeholder, bridge doesn't have this context
+		Type:    domain.PromptsPresetType,
+		Path:    prompt.Slug,
+	}
+
 	return *domain.NewPromptItem(
-		"", // packageName - placeholder, bridge doesn't have this context
-		"", // presetName - placeholder, bridge doesn't have this context
-		prompt.Slug,
+		uri,
 		prompt.Content,
 		domain.PromptMetadata{
 			Description: prompt.Metadata.Description,

--- a/internal/bridge/github-copilot_test.go
+++ b/internal/bridge/github-copilot_test.go
@@ -20,8 +20,14 @@ func TestVSCodeGitHubCopilotBridge_ToAgentRule(t *testing.T) {
 	}{
 		{
 			name: "AttachTypeAlways",
-			ruleItem: *domain.NewRuleItem("test-package", "test-preset",
-				"test-always",
+			ruleItem: *domain.NewRuleItem(
+				domain.URI{
+					Scheme:  domain.Scheme,
+					Package: "test-package",
+					Preset:  "test-preset",
+					Type:    domain.RulesPresetType,
+					Path:    "test-always",
+				},
 				"# Test Always\n\nThis rule is always applied.",
 				domain.RuleMetadata{
 					Attach: domain.AttachTypeAlways,
@@ -39,8 +45,14 @@ func TestVSCodeGitHubCopilotBridge_ToAgentRule(t *testing.T) {
 		},
 		{
 			name: "AttachTypeGlob",
-			ruleItem: *domain.NewRuleItem("test-package", "test-preset",
-				"test-glob",
+			ruleItem: *domain.NewRuleItem(
+				domain.URI{
+					Scheme:  domain.Scheme,
+					Package: "test-package",
+					Preset:  "test-preset",
+					Type:    domain.RulesPresetType,
+					Path:    "test-glob",
+				},
 				"# Test Glob\n\nThis rule applies to specific patterns.",
 				domain.RuleMetadata{
 					Attach: domain.AttachTypeGlob,
@@ -58,8 +70,14 @@ func TestVSCodeGitHubCopilotBridge_ToAgentRule(t *testing.T) {
 		},
 		{
 			name: "AttachTypeManual",
-			ruleItem: *domain.NewRuleItem("test-package", "test-preset",
-				"test-manual",
+			ruleItem: *domain.NewRuleItem(
+				domain.URI{
+					Scheme:  domain.Scheme,
+					Package: "test-package",
+					Preset:  "test-preset",
+					Type:    domain.RulesPresetType,
+					Path:    "test-manual",
+				},
 				"# Test Manual\n\nThis rule is applied manually.",
 				domain.RuleMetadata{
 					Attach: domain.AttachTypeManual,
@@ -75,8 +93,14 @@ func TestVSCodeGitHubCopilotBridge_ToAgentRule(t *testing.T) {
 		},
 		{
 			name: "AttachTypeAgentRequested",
-			ruleItem: *domain.NewRuleItem("test-package", "test-preset",
-				"test-agent-requested",
+			ruleItem: *domain.NewRuleItem(
+				domain.URI{
+					Scheme:  domain.Scheme,
+					Package: "test-package",
+					Preset:  "test-preset",
+					Type:    domain.RulesPresetType,
+					Path:    "test-agent-requested",
+				},
 				"# Test Agent\n\nThis rule is requested by agent.",
 				domain.RuleMetadata{
 					Attach: domain.AttachTypeAgentRequested,
@@ -92,8 +116,14 @@ func TestVSCodeGitHubCopilotBridge_ToAgentRule(t *testing.T) {
 		},
 		{
 			name: "manual attach type",
-			ruleItem: *domain.NewRuleItem("test-package", "test-preset",
-				"manual",
+			ruleItem: *domain.NewRuleItem(
+				domain.URI{
+					Scheme:  domain.Scheme,
+					Package: "test-package",
+					Preset:  "test-preset",
+					Type:    domain.RulesPresetType,
+					Path:    "manual",
+				},
 				"content",
 				domain.RuleMetadata{
 					Attach: domain.AttachTypeManual,
@@ -108,8 +138,14 @@ func TestVSCodeGitHubCopilotBridge_ToAgentRule(t *testing.T) {
 		},
 		{
 			name: "unsupported attach type falls back to manual",
-			ruleItem: *domain.NewRuleItem("test-package", "test-preset",
-				"unsupported",
+			ruleItem: *domain.NewRuleItem(
+				domain.URI{
+					Scheme:  domain.Scheme,
+					Package: "test-package",
+					Preset:  "test-preset",
+					Type:    domain.RulesPresetType,
+					Path:    "unsupported",
+				},
 				"content",
 				domain.RuleMetadata{
 					Attach: "unsupported",
@@ -157,8 +193,14 @@ func TestVSCodeGitHubCopilotBridge_FromAgentRule(t *testing.T) {
 					ApplyTo: bridge.GitHubCopilotApplyToAllPrimary,
 				},
 			},
-			expected: *domain.NewRuleItem("", "", // bridge doesn't have package/preset context
-				"test-all-primary",
+			expected: *domain.NewRuleItem(
+				domain.URI{
+					Scheme:  domain.Scheme,
+					Package: "", // bridge doesn't have package/preset context
+					Preset:  "", // bridge doesn't have package/preset context
+					Type:    domain.RulesPresetType,
+					Path:    "test-all-primary",
+				},
 				"# Test All Primary\n\nThis rule applies to all files (primary).",
 				domain.RuleMetadata{
 					Attach: domain.AttachTypeAlways,
@@ -176,8 +218,14 @@ func TestVSCodeGitHubCopilotBridge_FromAgentRule(t *testing.T) {
 					ApplyTo: bridge.GitHubCopilotApplyToAllSecondary,
 				},
 			},
-			expected: *domain.NewRuleItem("", "", // bridge doesn't have package/preset context
-				"test-all-secondary",
+			expected: *domain.NewRuleItem(
+				domain.URI{
+					Scheme:  domain.Scheme,
+					Package: "", // bridge doesn't have package/preset context
+					Preset:  "", // bridge doesn't have package/preset context
+					Type:    domain.RulesPresetType,
+					Path:    "test-all-secondary",
+				},
 				"# Test All Secondary\n\nThis rule applies to all files (secondary).",
 				domain.RuleMetadata{
 					Attach: domain.AttachTypeAlways,
@@ -195,8 +243,14 @@ func TestVSCodeGitHubCopilotBridge_FromAgentRule(t *testing.T) {
 					ApplyTo: "*.go,internal/**/*.go",
 				},
 			},
-			expected: *domain.NewRuleItem("", "", // bridge doesn't have package/preset context
-				"test-specific-globs",
+			expected: *domain.NewRuleItem(
+				domain.URI{
+					Scheme:  domain.Scheme,
+					Package: "", // bridge doesn't have package/preset context
+					Preset:  "", // bridge doesn't have package/preset context
+					Type:    domain.RulesPresetType,
+					Path:    "test-specific-globs",
+				},
 				"# Test Specific Globs\n\nThis rule applies to specific patterns.",
 				domain.RuleMetadata{
 					Attach: domain.AttachTypeGlob,
@@ -214,8 +268,14 @@ func TestVSCodeGitHubCopilotBridge_FromAgentRule(t *testing.T) {
 					ApplyTo: "",
 				},
 			},
-			expected: *domain.NewRuleItem("", "", // bridge doesn't have package/preset context
-				"test-empty-apply-to",
+			expected: *domain.NewRuleItem(
+				domain.URI{
+					Scheme:  domain.Scheme,
+					Package: "", // bridge doesn't have package/preset context
+					Preset:  "", // bridge doesn't have package/preset context
+					Type:    domain.RulesPresetType,
+					Path:    "test-empty-apply-to",
+				},
 				"# Test Empty ApplyTo\n\nThis rule has empty ApplyTo.",
 				domain.RuleMetadata{
 					Attach: domain.AttachTypeManual,
@@ -252,8 +312,14 @@ func TestVSCodeGitHubCopilotBridge_ToAgentPrompt(t *testing.T) {
 	}{
 		{
 			name: "BasicPrompt",
-			prompt: *domain.NewPromptItem("test-package", "test-preset",
-				"test-prompt",
+			prompt: *domain.NewPromptItem(
+				domain.URI{
+					Scheme:  domain.Scheme,
+					Package: "test-package",
+					Preset:  "test-preset",
+					Type:    domain.PromptsPresetType,
+					Path:    "test-prompt",
+				},
 				"# Test Prompt\n\nThis is a test prompt.",
 				domain.PromptMetadata{
 					Description: "A test prompt description",
@@ -307,8 +373,14 @@ func TestVSCodeGitHubCopilotBridge_FromAgentPrompt(t *testing.T) {
 					Tools:       []string{"tool1", "tool2"},
 				},
 			},
-			expected: *domain.NewPromptItem("", "", // bridge doesn't have package/preset context
-				"test-prompt",
+			expected: *domain.NewPromptItem(
+				domain.URI{
+					Scheme:  domain.Scheme,
+					Package: "", // bridge doesn't have package/preset context
+					Preset:  "", // bridge doesn't have package/preset context
+					Type:    domain.PromptsPresetType,
+					Path:    "test-prompt",
+				},
 				"# Test Prompt\n\nThis is a test prompt.",
 				domain.PromptMetadata{
 					Description: "A test prompt description",
@@ -327,8 +399,14 @@ func TestVSCodeGitHubCopilotBridge_FromAgentPrompt(t *testing.T) {
 					Tools:       []string{},
 				},
 			},
-			expected: *domain.NewPromptItem("", "", // bridge doesn't have package/preset context
-				"test-prompt-empty",
+			expected: *domain.NewPromptItem(
+				domain.URI{
+					Scheme:  domain.Scheme,
+					Package: "", // bridge doesn't have package/preset context
+					Preset:  "", // bridge doesn't have package/preset context
+					Type:    domain.PromptsPresetType,
+					Path:    "test-prompt-empty",
+				},
 				"# Test Empty\n\nThis prompt has empty description.",
 				domain.PromptMetadata{
 					Description: "",

--- a/internal/bridge/windsurf.go
+++ b/internal/bridge/windsurf.go
@@ -102,11 +102,18 @@ func (bridge *WindsurfBridge) ToAgentRule(rule domain.RuleItem) (WindsurfRule, e
 func (bridge *WindsurfBridge) FromAgentRule(rule WindsurfRule) (domain.RuleItem, error) {
 	emptyGlobs := make([]string, 0)
 
+	// Create URI with placeholder values since bridge doesn't have package/preset context
+	uri := domain.URI{
+		Scheme:  domain.Scheme,
+		Package: "", // placeholder, bridge doesn't have this context
+		Preset:  "", // placeholder, bridge doesn't have this context
+		Type:    domain.RulesPresetType,
+		Path:    rule.Slug,
+	}
+
 	if rule.Metadata.Trigger == WindsurfTriggerTypeAlways {
 		return *domain.NewRuleItem(
-			"", // packageName - placeholder, bridge doesn't have this context
-			"", // presetName - placeholder, bridge doesn't have this context
-			rule.Slug,
+			uri,
 			rule.Content,
 			domain.RuleMetadata{
 				Attach:      domain.AttachTypeAlways,
@@ -118,9 +125,7 @@ func (bridge *WindsurfBridge) FromAgentRule(rule WindsurfRule) (domain.RuleItem,
 
 	if rule.Metadata.Trigger == WindsurfTriggerTypeGlob {
 		return *domain.NewRuleItem(
-			"", // packageName - placeholder, bridge doesn't have this context
-			"", // presetName - placeholder, bridge doesn't have this context
-			rule.Slug,
+			uri,
 			rule.Content,
 			domain.RuleMetadata{
 				Attach:      domain.AttachTypeGlob,
@@ -132,9 +137,7 @@ func (bridge *WindsurfBridge) FromAgentRule(rule WindsurfRule) (domain.RuleItem,
 
 	if rule.Metadata.Trigger == WindsurfTriggerTypeAgentRequested {
 		return *domain.NewRuleItem(
-			"", // packageName - placeholder, bridge doesn't have this context
-			"", // presetName - placeholder, bridge doesn't have this context
-			rule.Slug,
+			uri,
 			rule.Content,
 			domain.RuleMetadata{
 				Attach:      domain.AttachTypeAgentRequested,
@@ -146,9 +149,7 @@ func (bridge *WindsurfBridge) FromAgentRule(rule WindsurfRule) (domain.RuleItem,
 
 	if rule.Metadata.Trigger == WindsurfTriggerTypeManual {
 		return *domain.NewRuleItem(
-			"", // packageName - placeholder, bridge doesn't have this context
-			"", // presetName - placeholder, bridge doesn't have this context
-			rule.Slug,
+			uri,
 			rule.Content,
 			domain.RuleMetadata{
 				Attach:      domain.AttachTypeManual,
@@ -169,10 +170,17 @@ func (bridge *WindsurfBridge) ToAgentPrompt(prompt domain.PromptItem) (WindsurfP
 }
 
 func (bridge *WindsurfBridge) FromAgentPrompt(prompt WindsurfPrompt) (domain.PromptItem, error) {
+	// Create URI with placeholder values since bridge doesn't have package/preset context
+	uri := domain.URI{
+		Scheme:  domain.Scheme,
+		Package: "", // placeholder, bridge doesn't have this context
+		Preset:  "", // placeholder, bridge doesn't have this context
+		Type:    domain.PromptsPresetType,
+		Path:    prompt.Slug,
+	}
+
 	return *domain.NewPromptItem(
-		"", // packageName - placeholder, bridge doesn't have this context
-		"", // presetName - placeholder, bridge doesn't have this context
-		prompt.Slug,
+		uri,
 		prompt.Content,
 		domain.PromptMetadata{},
 	), nil

--- a/internal/bridge/windsurf.go
+++ b/internal/bridge/windsurf.go
@@ -102,14 +102,8 @@ func (bridge *WindsurfBridge) ToAgentRule(rule domain.RuleItem) (WindsurfRule, e
 func (bridge *WindsurfBridge) FromAgentRule(rule WindsurfRule) (domain.RuleItem, error) {
 	emptyGlobs := make([]string, 0)
 
-	// Create URI with placeholder values since bridge doesn't have package/preset context
-	uri := domain.URI{
-		Scheme:  domain.Scheme,
-		Package: "", // placeholder, bridge doesn't have this context
-		Preset:  "", // placeholder, bridge doesn't have this context
-		Type:    domain.RulesPresetType,
-		Path:    rule.Slug,
-	}
+	// Create URI using the domain.NewPlaceholderURI helper
+	uri := domain.NewPlaceholderURI(rule.Slug, domain.RulesPresetType)
 
 	if rule.Metadata.Trigger == WindsurfTriggerTypeAlways {
 		return *domain.NewRuleItem(
@@ -170,14 +164,8 @@ func (bridge *WindsurfBridge) ToAgentPrompt(prompt domain.PromptItem) (WindsurfP
 }
 
 func (bridge *WindsurfBridge) FromAgentPrompt(prompt WindsurfPrompt) (domain.PromptItem, error) {
-	// Create URI with placeholder values since bridge doesn't have package/preset context
-	uri := domain.URI{
-		Scheme:  domain.Scheme,
-		Package: "", // placeholder, bridge doesn't have this context
-		Preset:  "", // placeholder, bridge doesn't have this context
-		Type:    domain.PromptsPresetType,
-		Path:    prompt.Slug,
-	}
+	// Create URI using the domain.NewPlaceholderURI helper
+	uri := domain.NewPlaceholderURI(prompt.Slug, domain.PromptsPresetType)
 
 	return *domain.NewPromptItem(
 		uri,

--- a/internal/bridge/windsurf_test.go
+++ b/internal/bridge/windsurf_test.go
@@ -157,8 +157,14 @@ func TestWindsurfBridge_ToAgentRule(t *testing.T) {
 	}{
 		{
 			name: "Always Attach Type",
-			domainRule: *domain.NewRuleItem("test-package", "test-preset",
-				"always",
+			domainRule: *domain.NewRuleItem(
+				domain.URI{
+					Scheme:  domain.Scheme,
+					Package: "test-package",
+					Preset:  "test-preset",
+					Type:    domain.RulesPresetType,
+					Path:    "always",
+				},
 				"Always",
 				domain.RuleMetadata{
 					Attach: domain.AttachTypeAlways,
@@ -177,8 +183,14 @@ func TestWindsurfBridge_ToAgentRule(t *testing.T) {
 		},
 		{
 			name: "Glob Attach Type",
-			domainRule: *domain.NewRuleItem("test-package", "test-preset",
-				"go",
+			domainRule: *domain.NewRuleItem(
+				domain.URI{
+					Scheme:  domain.Scheme,
+					Package: "test-package",
+					Preset:  "test-preset",
+					Type:    domain.RulesPresetType,
+					Path:    "go",
+				},
 				"You should print \"GOGO!\"",
 				domain.RuleMetadata{
 					Attach: domain.AttachTypeGlob,
@@ -197,8 +209,14 @@ func TestWindsurfBridge_ToAgentRule(t *testing.T) {
 		},
 		{
 			name: "Agent Requested Attach Type",
-			domainRule: *domain.NewRuleItem("test-package", "test-preset",
-				"model-decision",
+			domainRule: *domain.NewRuleItem(
+				domain.URI{
+					Scheme:  domain.Scheme,
+					Package: "test-package",
+					Preset:  "test-preset",
+					Type:    domain.RulesPresetType,
+					Path:    "model-decision",
+				},
 				"HeyHeyHey",
 				domain.RuleMetadata{
 					Attach:      domain.AttachTypeAgentRequested,
@@ -218,8 +236,14 @@ func TestWindsurfBridge_ToAgentRule(t *testing.T) {
 		},
 		{
 			name: "Manual Attach Type",
-			domainRule: *domain.NewRuleItem("test-package", "test-preset",
-				"manual",
+			domainRule: *domain.NewRuleItem(
+				domain.URI{
+					Scheme:  domain.Scheme,
+					Package: "test-package",
+					Preset:  "test-preset",
+					Type:    domain.RulesPresetType,
+					Path:    "manual",
+				},
 				"Content",
 				domain.RuleMetadata{
 					Attach: domain.AttachTypeManual,
@@ -238,8 +262,14 @@ func TestWindsurfBridge_ToAgentRule(t *testing.T) {
 		},
 		{
 			name: "unsupported attach type falls back to manual",
-			domainRule: *domain.NewRuleItem("test-package", "test-preset",
-				"unsupported",
+			domainRule: *domain.NewRuleItem(
+				domain.URI{
+					Scheme:  domain.Scheme,
+					Package: "test-package",
+					Preset:  "test-preset",
+					Type:    domain.RulesPresetType,
+					Path:    "unsupported",
+				},
 				"content",
 				domain.RuleMetadata{
 					Attach: "unsupported",
@@ -288,8 +318,14 @@ func TestWindsurfBridge_FromAgentRule(t *testing.T) {
 					Trigger: bridge.WindsurfTriggerTypeAlways,
 				},
 			},
-			expectedRule: *domain.NewRuleItem("", "", // bridge doesn't have package/preset context
-				"always",
+			expectedRule: *domain.NewRuleItem(
+				domain.URI{
+					Scheme:  domain.Scheme,
+					Package: "", // bridge doesn't have package/preset context
+					Preset:  "", // bridge doesn't have package/preset context
+					Type:    domain.RulesPresetType,
+					Path:    "always",
+				},
 				"Always",
 				domain.RuleMetadata{
 					Attach:      domain.AttachTypeAlways,
@@ -308,8 +344,14 @@ func TestWindsurfBridge_FromAgentRule(t *testing.T) {
 					Globs:   "**/*.go,**/*.yaml",
 				},
 			},
-			expectedRule: *domain.NewRuleItem("", "", // bridge doesn't have package/preset context
-				"go",
+			expectedRule: *domain.NewRuleItem(
+				domain.URI{
+					Scheme:  domain.Scheme,
+					Package: "", // bridge doesn't have package/preset context
+					Preset:  "", // bridge doesn't have package/preset context
+					Type:    domain.RulesPresetType,
+					Path:    "go",
+				},
 				"You should print \"GOGO!\"",
 				domain.RuleMetadata{
 					Attach:      domain.AttachTypeGlob,
@@ -328,8 +370,14 @@ func TestWindsurfBridge_FromAgentRule(t *testing.T) {
 					Description: longModelDecisionDescription,
 				},
 			},
-			expectedRule: *domain.NewRuleItem("", "", // bridge doesn't have package/preset context
-				"model-decision",
+			expectedRule: *domain.NewRuleItem(
+				domain.URI{
+					Scheme:  domain.Scheme,
+					Package: "", // bridge doesn't have package/preset context
+					Preset:  "", // bridge doesn't have package/preset context
+					Type:    domain.RulesPresetType,
+					Path:    "model-decision",
+				},
 				"HeyHeyHey",
 				domain.RuleMetadata{
 					Attach:      domain.AttachTypeAgentRequested,
@@ -347,8 +395,14 @@ func TestWindsurfBridge_FromAgentRule(t *testing.T) {
 					Trigger: bridge.WindsurfTriggerTypeManual,
 				},
 			},
-			expectedRule: *domain.NewRuleItem("", "", // bridge doesn't have package/preset context
-				"manual",
+			expectedRule: *domain.NewRuleItem(
+				domain.URI{
+					Scheme:  domain.Scheme,
+					Package: "", // bridge doesn't have package/preset context
+					Preset:  "", // bridge doesn't have package/preset context
+					Type:    domain.RulesPresetType,
+					Path:    "manual",
+				},
 				"Content",
 				domain.RuleMetadata{
 					Attach:      domain.AttachTypeManual,
@@ -388,8 +442,14 @@ func TestWindsurfBridge_PromptConversion(t *testing.T) {
 	bridgeInstance := bridge.NewWindsurfBridge()
 
 	// Test ToAgentPrompt
-	domainPrompt := *domain.NewPromptItem("test-package", "test-preset",
-		"test-prompt",
+	domainPrompt := *domain.NewPromptItem(
+		domain.URI{
+			Scheme:  domain.Scheme,
+			Package: "test-package",
+			Preset:  "test-preset",
+			Type:    domain.PromptsPresetType,
+			Path:    "test-prompt",
+		},
 		"This is a test prompt.",
 		domain.PromptMetadata{},
 	)
@@ -405,8 +465,14 @@ func TestWindsurfBridge_PromptConversion(t *testing.T) {
 		Content: "This is a Windsurf prompt.",
 	}
 
-	expectedDomainPrompt := *domain.NewPromptItem("", "", // bridge doesn't have package/preset context
-		"windsurf-prompt",
+	expectedDomainPrompt := *domain.NewPromptItem(
+		domain.URI{
+			Scheme:  domain.Scheme,
+			Package: "", // bridge doesn't have package/preset context
+			Preset:  "", // bridge doesn't have package/preset context
+			Type:    domain.PromptsPresetType,
+			Path:    "windsurf-prompt",
+		},
 		"This is a Windsurf prompt.",
 		domain.PromptMetadata{},
 	)

--- a/internal/domain/package_test.go
+++ b/internal/domain/package_test.go
@@ -51,9 +51,13 @@ func TestAgentPresetPackage_MarshalToXML(t *testing.T) {
 						Name: "test-preset",
 						Rules: []*domain.RuleItem{
 							domain.NewRuleItem(
-								"test-package",
-								"test-preset",
-								"test-rule",
+								domain.URI{
+									Scheme:  domain.Scheme,
+									Package: "test-package",
+									Preset:  "test-preset",
+									Type:    domain.RulesPresetType,
+									Path:    "test-rule",
+								},
 								"# Test Rule",
 								domain.RuleMetadata{},
 							),
@@ -85,9 +89,13 @@ func TestAgentPresetPackage_MarshalToXML(t *testing.T) {
 						Rules: nil,
 						Prompts: []*domain.PromptItem{
 							domain.NewPromptItem(
-								"test-package",
-								"test-preset",
-								"test-prompt",
+								domain.URI{
+									Scheme:  domain.Scheme,
+									Package: "test-package",
+									Preset:  "test-preset",
+									Type:    domain.PromptsPresetType,
+									Path:    "test-prompt",
+								},
 								"# Test Prompt",
 								domain.PromptMetadata{},
 							),
@@ -116,7 +124,17 @@ func TestAgentPresetPackage_MarshalToXML(t *testing.T) {
 					{
 						Name: "preset1",
 						Rules: []*domain.RuleItem{
-							domain.NewRuleItem("test-package", "preset1", "rule1", "# Rule One", domain.RuleMetadata{}),
+							domain.NewRuleItem(
+								domain.URI{
+									Scheme:  domain.Scheme,
+									Package: "test-package",
+									Preset:  "preset1",
+									Type:    domain.RulesPresetType,
+									Path:    "rule1",
+								},
+								"# Rule One",
+								domain.RuleMetadata{},
+							),
 						},
 						Prompts: nil,
 					},
@@ -125,9 +143,13 @@ func TestAgentPresetPackage_MarshalToXML(t *testing.T) {
 						Rules: nil,
 						Prompts: []*domain.PromptItem{
 							domain.NewPromptItem(
-								"test-package",
-								"preset2",
-								"prompt2",
+								domain.URI{
+									Scheme:  domain.Scheme,
+									Package: "test-package",
+									Preset:  "preset2",
+									Type:    domain.PromptsPresetType,
+									Path:    "prompt2",
+								},
 								"# Prompt Two",
 								domain.PromptMetadata{},
 							),

--- a/internal/domain/preset_test.go
+++ b/internal/domain/preset_test.go
@@ -78,7 +78,14 @@ func TestNewRuleItem(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := domain.NewRuleItem("test-package", "test-preset", tt.slug, tt.content, tt.metadata)
+			uri := domain.URI{
+				Scheme:  domain.Scheme,
+				Package: "test-package",
+				Preset:  "test-preset",
+				Type:    domain.RulesPresetType,
+				Path:    tt.slug,
+			}
+			result := domain.NewRuleItem(uri, tt.content, tt.metadata)
 
 			assert.Equal(t, tt.slug, result.URI.Path)
 			assert.Equal(t, tt.content, result.Content)
@@ -148,7 +155,14 @@ func TestNewPromptItem(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := domain.NewPromptItem("test-package", "test-preset", tt.slug, tt.content, tt.metadata)
+			uri := domain.URI{
+				Scheme:  domain.Scheme,
+				Package: "test-package",
+				Preset:  "test-preset",
+				Type:    domain.PromptsPresetType,
+				Path:    tt.slug,
+			}
+			result := domain.NewPromptItem(uri, tt.content, tt.metadata)
 
 			assert.Equal(t, tt.slug, result.URI.Path)
 			assert.Equal(t, tt.content, result.Content)
@@ -179,16 +193,24 @@ func TestAgentPreset_ToXML(t *testing.T) {
 				Name: "rules-only",
 				Rules: []*domain.RuleItem{
 					domain.NewRuleItem(
-						"test-package",
-						"rules-only",
-						"rule1",
+						domain.URI{
+							Scheme:  domain.Scheme,
+							Package: "test-package",
+							Preset:  "rules-only",
+							Type:    domain.RulesPresetType,
+							Path:    "rule1",
+						},
 						"Rule 1 content",
 						domain.RuleMetadata{Description: "Rule 1 desc", Attach: domain.AttachTypeAlways},
 					),
 					domain.NewRuleItem(
-						"test-package",
-						"rules-only",
-						"rule2",
+						domain.URI{
+							Scheme:  domain.Scheme,
+							Package: "test-package",
+							Preset:  "rules-only",
+							Type:    domain.RulesPresetType,
+							Path:    "rule2",
+						},
 						"Rule 2 content",
 						domain.RuleMetadata{
 							Description: "Rule 2 desc",
@@ -226,16 +248,24 @@ func TestAgentPreset_ToXML(t *testing.T) {
 				Rules: nil,
 				Prompts: []*domain.PromptItem{
 					domain.NewPromptItem(
-						"test-package",
-						"prompts-only",
-						"prompt1",
+						domain.URI{
+							Scheme:  domain.Scheme,
+							Package: "test-package",
+							Preset:  "prompts-only",
+							Type:    domain.PromptsPresetType,
+							Path:    "prompt1",
+						},
 						"Prompt 1 content",
 						domain.PromptMetadata{Description: "Prompt 1 desc"},
 					),
 					domain.NewPromptItem(
-						"test-package",
-						"prompts-only",
-						"prompt2",
+						domain.URI{
+							Scheme:  domain.Scheme,
+							Package: "test-package",
+							Preset:  "prompts-only",
+							Type:    domain.PromptsPresetType,
+							Path:    "prompt2",
+						},
 						"Prompt 2 content",
 						domain.PromptMetadata{Description: "Prompt 2 desc"},
 					),
@@ -262,18 +292,26 @@ func TestAgentPreset_ToXML(t *testing.T) {
 				Name: "mixed-preset",
 				Rules: []*domain.RuleItem{
 					domain.NewRuleItem(
-						"test-package",
-						"mixed-preset",
-						"rule1",
+						domain.URI{
+							Scheme:  domain.Scheme,
+							Package: "test-package",
+							Preset:  "mixed-preset",
+							Type:    domain.RulesPresetType,
+							Path:    "rule1",
+						},
 						"Rule content",
 						domain.RuleMetadata{Description: "Rule desc", Attach: domain.AttachTypeManual},
 					),
 				},
 				Prompts: []*domain.PromptItem{
 					domain.NewPromptItem(
-						"test-package",
-						"mixed-preset",
-						"prompt1",
+						domain.URI{
+							Scheme:  domain.Scheme,
+							Package: "test-package",
+							Preset:  "mixed-preset",
+							Type:    domain.PromptsPresetType,
+							Path:    "prompt1",
+						},
 						"Prompt content",
 						domain.PromptMetadata{Description: "Prompt desc"},
 					),

--- a/internal/domain/prompt.go
+++ b/internal/domain/prompt.go
@@ -18,7 +18,7 @@ type (
 	}
 )
 
-func NewPromptItem(packageName, presetName, path, content string, metadata PromptMetadata) *PromptItem {
+func NewPromptItem(uri URI, content string, metadata PromptMetadata) *PromptItem {
 	var resolvedDescription string
 	if metadata.Description != "" {
 		resolvedDescription = metadata.Description
@@ -35,13 +35,7 @@ func NewPromptItem(packageName, presetName, path, content string, metadata Promp
 		presetItem: presetItem{
 			Type:    PromptsPresetType,
 			Content: content,
-			URI: URI{
-				Scheme:  Scheme,
-				Package: packageName,
-				Preset:  presetName,
-				Type:    PromptsPresetType,
-				Path:    path,
-			},
+			URI:     uri,
 		},
 		Metadata: resolvedMetadata,
 	}

--- a/internal/domain/rule.go
+++ b/internal/domain/rule.go
@@ -20,7 +20,7 @@ type (
 	}
 )
 
-func NewRuleItem(packageName, presetName, path, content string, metadata RuleMetadata) *RuleItem {
+func NewRuleItem(uri URI, content string, metadata RuleMetadata) *RuleItem {
 	var resolvedDescription string
 	if metadata.Description != "" {
 		resolvedDescription = metadata.Description
@@ -37,13 +37,7 @@ func NewRuleItem(packageName, presetName, path, content string, metadata RuleMet
 		presetItem: presetItem{
 			Type:    RulesPresetType,
 			Content: content,
-			URI: URI{
-				Scheme:  Scheme,
-				Package: packageName,
-				Preset:  presetName,
-				Type:    RulesPresetType,
-				Path:    path,
-			},
+			URI:     uri,
 		},
 		Metadata: resolvedMetadata,
 	}

--- a/internal/domain/uri.go
+++ b/internal/domain/uri.go
@@ -28,7 +28,7 @@ func (u *URI) String() string {
 }
 
 // GetInternalPath generates the relative path for writing to agent filesystem
-// from the URI (e.g., "test-package/test-preset/my/rule.md").
+// from the URI. (e.g., "test-package/test-preset/my/rule.md")
 func (u *URI) GetInternalPath(extension string) string {
 	// u.Path is in format like "my/rule", so we add the extension
 	return filepath.Join(u.Package, u.Preset, u.Path+extension)

--- a/internal/domain/uri.go
+++ b/internal/domain/uri.go
@@ -21,6 +21,18 @@ type URI struct {
 	Path    string     // Hierarchical path within preset (e.g., "go-style/project")
 }
 
+// NewPlaceholderURI creates a placeholder URI for operations that don't have package/preset context.
+// This is commonly used in bridge operations where the package and preset information is not available.
+func NewPlaceholderURI(slug string, itemType PresetType) URI {
+	return URI{
+		Scheme:  Scheme,
+		Package: "", // placeholder, context doesn't have this information
+		Preset:  "", // placeholder, context doesn't have this information
+		Type:    itemType,
+		Path:    slug,
+	}
+}
+
 // String converts the URI structure to its string representation.
 // Example: "ajisai://local_rules/default/rules/go-style/project"
 func (u *URI) String() string {

--- a/internal/domain/uri.go
+++ b/internal/domain/uri.go
@@ -28,7 +28,7 @@ func (u *URI) String() string {
 }
 
 // GetInternalPath generates the relative path for writing to agent filesystem
-// from the URI. (e.g., "test-package/test-preset/my/rule.md")
+// from the URI (e.g., "test-package/test-preset/my/rule.md").
 func (u *URI) GetInternalPath(extension string) string {
 	// u.Path is in format like "my/rule", so we add the extension
 	return filepath.Join(u.Package, u.Preset, u.Path+extension)

--- a/internal/domain/uri_test.go
+++ b/internal/domain/uri_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/sushichan044/ajisai/internal/domain"
 )
@@ -183,7 +182,7 @@ func TestGetPathFromBaseDir(t *testing.T) {
 			if tt.expectError {
 				assert.Error(t, err)
 			} else {
-				require.NoError(t, err)
+				assert.NoError(t, err)
 				assert.Equal(t, tt.expected, result)
 			}
 		})

--- a/internal/domain/uri_test.go
+++ b/internal/domain/uri_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/sushichan044/ajisai/internal/domain"
 )
@@ -182,7 +183,7 @@ func TestGetPathFromBaseDir(t *testing.T) {
 			if tt.expectError {
 				assert.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, tt.expected, result)
 			}
 		})

--- a/internal/integration/cursor_test.go
+++ b/internal/integration/cursor_test.go
@@ -22,7 +22,7 @@ func TestCursorAdapter_SerializeRule(t *testing.T) {
 	// Setup
 	adapter := integration.NewCursorAdapter()
 	rule := domain.NewRuleItem(
-		makeTestURI("test-preset", "test-rule", domain.RulesPresetType),
+		makeTestURI("test-rule", domain.RulesPresetType),
 		"# Test Rule\nThis is a test rule.",
 		domain.RuleMetadata{
 			Description: "Test Rule Description",
@@ -45,7 +45,7 @@ func TestCursorAdapter_SerializePrompt(t *testing.T) {
 	// Setup
 	adapter := integration.NewCursorAdapter()
 	prompt := domain.NewPromptItem(
-		makeTestURI("test-preset", "test-prompt", domain.PromptsPresetType),
+		makeTestURI("test-prompt", domain.PromptsPresetType),
 		"# Test Prompt\nThis is a test prompt.",
 		domain.PromptMetadata{
 			Description: "Test Prompt Description",

--- a/internal/integration/cursor_test.go
+++ b/internal/integration/cursor_test.go
@@ -22,13 +22,7 @@ func TestCursorAdapter_SerializeRule(t *testing.T) {
 	// Setup
 	adapter := integration.NewCursorAdapter()
 	rule := domain.NewRuleItem(
-		domain.URI{
-			Scheme:  domain.Scheme,
-			Package: "test-package",
-			Preset:  "test-preset",
-			Type:    domain.RulesPresetType,
-			Path:    "test-rule",
-		},
+		makeTestURI("test-preset", "test-rule", domain.RulesPresetType),
 		"# Test Rule\nThis is a test rule.",
 		domain.RuleMetadata{
 			Description: "Test Rule Description",
@@ -51,13 +45,7 @@ func TestCursorAdapter_SerializePrompt(t *testing.T) {
 	// Setup
 	adapter := integration.NewCursorAdapter()
 	prompt := domain.NewPromptItem(
-		domain.URI{
-			Scheme:  domain.Scheme,
-			Package: "test-package",
-			Preset:  "test-preset",
-			Type:    domain.PromptsPresetType,
-			Path:    "test-prompt",
-		},
+		makeTestURI("test-preset", "test-prompt", domain.PromptsPresetType),
 		"# Test Prompt\nThis is a test prompt.",
 		domain.PromptMetadata{
 			Description: "Test Prompt Description",

--- a/internal/integration/cursor_test.go
+++ b/internal/integration/cursor_test.go
@@ -21,11 +21,17 @@ func TestCursorAdapter_NewCursorAdapter(t *testing.T) {
 func TestCursorAdapter_SerializeRule(t *testing.T) {
 	// Setup
 	adapter := integration.NewCursorAdapter()
-	rule := domain.NewRuleItem("test-package", "test-preset", "test-rule", "# Test Rule\nThis is a test rule.", domain.RuleMetadata{
-		Description: "Test Rule Description",
-		Attach:      domain.AttachTypeAlways,
-		Globs:       []string{"**/*.go"},
-	})
+	rule := domain.NewRuleItem(
+		"test-package",
+		"test-preset",
+		"test-rule",
+		"# Test Rule\nThis is a test rule.",
+		domain.RuleMetadata{
+			Description: "Test Rule Description",
+			Attach:      domain.AttachTypeAlways,
+			Globs:       []string{"**/*.go"},
+		},
+	)
 
 	// Execute
 	serialized, err := adapter.SerializeRule(rule)
@@ -40,9 +46,15 @@ func TestCursorAdapter_SerializeRule(t *testing.T) {
 func TestCursorAdapter_SerializePrompt(t *testing.T) {
 	// Setup
 	adapter := integration.NewCursorAdapter()
-	prompt := domain.NewPromptItem("test-package", "test-preset", "test-prompt", "# Test Prompt\nThis is a test prompt.", domain.PromptMetadata{
-		Description: "Test Prompt Description",
-	})
+	prompt := domain.NewPromptItem(
+		"test-package",
+		"test-preset",
+		"test-prompt",
+		"# Test Prompt\nThis is a test prompt.",
+		domain.PromptMetadata{
+			Description: "Test Prompt Description",
+		},
+	)
 
 	// Execute
 	serialized, err := adapter.SerializePrompt(prompt)

--- a/internal/integration/cursor_test.go
+++ b/internal/integration/cursor_test.go
@@ -21,17 +21,11 @@ func TestCursorAdapter_NewCursorAdapter(t *testing.T) {
 func TestCursorAdapter_SerializeRule(t *testing.T) {
 	// Setup
 	adapter := integration.NewCursorAdapter()
-	rule := domain.NewRuleItem(
-		"test-package",
-		"test-preset",
-		"test-rule",
-		"# Test Rule\nThis is a test rule.",
-		domain.RuleMetadata{
-			Description: "Test Rule Description",
-			Attach:      domain.AttachTypeAlways,
-			Globs:       []string{"**/*.go"},
-		},
-	)
+	rule := domain.NewRuleItem("test-package", "test-preset", "test-rule", "# Test Rule\nThis is a test rule.", domain.RuleMetadata{
+		Description: "Test Rule Description",
+		Attach:      domain.AttachTypeAlways,
+		Globs:       []string{"**/*.go"},
+	})
 
 	// Execute
 	serialized, err := adapter.SerializeRule(rule)
@@ -46,15 +40,9 @@ func TestCursorAdapter_SerializeRule(t *testing.T) {
 func TestCursorAdapter_SerializePrompt(t *testing.T) {
 	// Setup
 	adapter := integration.NewCursorAdapter()
-	prompt := domain.NewPromptItem(
-		"test-package",
-		"test-preset",
-		"test-prompt",
-		"# Test Prompt\nThis is a test prompt.",
-		domain.PromptMetadata{
-			Description: "Test Prompt Description",
-		},
-	)
+	prompt := domain.NewPromptItem("test-package", "test-preset", "test-prompt", "# Test Prompt\nThis is a test prompt.", domain.PromptMetadata{
+		Description: "Test Prompt Description",
+	})
 
 	// Execute
 	serialized, err := adapter.SerializePrompt(prompt)

--- a/internal/integration/cursor_test.go
+++ b/internal/integration/cursor_test.go
@@ -22,9 +22,13 @@ func TestCursorAdapter_SerializeRule(t *testing.T) {
 	// Setup
 	adapter := integration.NewCursorAdapter()
 	rule := domain.NewRuleItem(
-		"test-package",
-		"test-preset",
-		"test-rule",
+		domain.URI{
+			Scheme:  domain.Scheme,
+			Package: "test-package",
+			Preset:  "test-preset",
+			Type:    domain.RulesPresetType,
+			Path:    "test-rule",
+		},
 		"# Test Rule\nThis is a test rule.",
 		domain.RuleMetadata{
 			Description: "Test Rule Description",
@@ -47,9 +51,13 @@ func TestCursorAdapter_SerializePrompt(t *testing.T) {
 	// Setup
 	adapter := integration.NewCursorAdapter()
 	prompt := domain.NewPromptItem(
-		"test-package",
-		"test-preset",
-		"test-prompt",
+		domain.URI{
+			Scheme:  domain.Scheme,
+			Package: "test-package",
+			Preset:  "test-preset",
+			Type:    domain.PromptsPresetType,
+			Path:    "test-prompt",
+		},
 		"# Test Prompt\nThis is a test prompt.",
 		domain.PromptMetadata{
 			Description: "Test Prompt Description",

--- a/internal/integration/github-copilot_test.go
+++ b/internal/integration/github-copilot_test.go
@@ -21,11 +21,17 @@ func TestGitHubCopilotAdapter_NewGitHubCopilotAdapter(t *testing.T) {
 func TestGitHubCopilotAdapter_SerializeRule(t *testing.T) {
 	// Setup
 	adapter := integration.NewGitHubCopilotAdapter()
-	rule := domain.NewRuleItem("test-package", "test-preset", "test-rule", "# Test Rule\nThis is a test rule.", domain.RuleMetadata{
-		Description: "Test Rule Description",
-		Attach:      domain.AttachTypeAlways,
-		Globs:       []string{"**/*.go"},
-	})
+	rule := domain.NewRuleItem(
+		"test-package",
+		"test-preset",
+		"test-rule",
+		"# Test Rule\nThis is a test rule.",
+		domain.RuleMetadata{
+			Description: "Test Rule Description",
+			Attach:      domain.AttachTypeAlways,
+			Globs:       []string{"**/*.go"},
+		},
+	)
 
 	// Execute
 	serialized, err := adapter.SerializeRule(rule)
@@ -40,9 +46,15 @@ func TestGitHubCopilotAdapter_SerializeRule(t *testing.T) {
 func TestGitHubCopilotAdapter_SerializePrompt(t *testing.T) {
 	// Setup
 	adapter := integration.NewGitHubCopilotAdapter()
-	prompt := domain.NewPromptItem("test-package", "test-preset", "test-prompt", "# Test Prompt\nThis is a test prompt.", domain.PromptMetadata{
-		Description: "Test Prompt Description",
-	})
+	prompt := domain.NewPromptItem(
+		"test-package",
+		"test-preset",
+		"test-prompt",
+		"# Test Prompt\nThis is a test prompt.",
+		domain.PromptMetadata{
+			Description: "Test Prompt Description",
+		},
+	)
 
 	// Execute
 	serialized, err := adapter.SerializePrompt(prompt)

--- a/internal/integration/github-copilot_test.go
+++ b/internal/integration/github-copilot_test.go
@@ -22,7 +22,7 @@ func TestGitHubCopilotAdapter_SerializeRule(t *testing.T) {
 	// Setup
 	adapter := integration.NewGitHubCopilotAdapter()
 	rule := domain.NewRuleItem(
-		makeTestURI("test-preset", "test-rule", domain.RulesPresetType),
+		makeTestURI("test-rule", domain.RulesPresetType),
 		"# Test Rule\nThis is a test rule.",
 		domain.RuleMetadata{
 			Description: "Test Rule Description",
@@ -45,7 +45,7 @@ func TestGitHubCopilotAdapter_SerializePrompt(t *testing.T) {
 	// Setup
 	adapter := integration.NewGitHubCopilotAdapter()
 	prompt := domain.NewPromptItem(
-		makeTestURI("test-preset", "test-prompt", domain.PromptsPresetType),
+		makeTestURI("test-prompt", domain.PromptsPresetType),
 		"# Test Prompt\nThis is a test prompt.",
 		domain.PromptMetadata{
 			Description: "Test Prompt Description",

--- a/internal/integration/github-copilot_test.go
+++ b/internal/integration/github-copilot_test.go
@@ -22,9 +22,13 @@ func TestGitHubCopilotAdapter_SerializeRule(t *testing.T) {
 	// Setup
 	adapter := integration.NewGitHubCopilotAdapter()
 	rule := domain.NewRuleItem(
-		"test-package",
-		"test-preset",
-		"test-rule",
+		domain.URI{
+			Scheme:  domain.Scheme,
+			Package: "test-package",
+			Preset:  "test-preset",
+			Type:    domain.RulesPresetType,
+			Path:    "test-rule",
+		},
 		"# Test Rule\nThis is a test rule.",
 		domain.RuleMetadata{
 			Description: "Test Rule Description",
@@ -47,9 +51,13 @@ func TestGitHubCopilotAdapter_SerializePrompt(t *testing.T) {
 	// Setup
 	adapter := integration.NewGitHubCopilotAdapter()
 	prompt := domain.NewPromptItem(
-		"test-package",
-		"test-preset",
-		"test-prompt",
+		domain.URI{
+			Scheme:  domain.Scheme,
+			Package: "test-package",
+			Preset:  "test-preset",
+			Type:    domain.PromptsPresetType,
+			Path:    "test-prompt",
+		},
 		"# Test Prompt\nThis is a test prompt.",
 		domain.PromptMetadata{
 			Description: "Test Prompt Description",

--- a/internal/integration/github-copilot_test.go
+++ b/internal/integration/github-copilot_test.go
@@ -21,17 +21,11 @@ func TestGitHubCopilotAdapter_NewGitHubCopilotAdapter(t *testing.T) {
 func TestGitHubCopilotAdapter_SerializeRule(t *testing.T) {
 	// Setup
 	adapter := integration.NewGitHubCopilotAdapter()
-	rule := domain.NewRuleItem(
-		"test-package",
-		"test-preset",
-		"test-rule",
-		"# Test Rule\nThis is a test rule.",
-		domain.RuleMetadata{
-			Description: "Test Rule Description",
-			Attach:      domain.AttachTypeAlways,
-			Globs:       []string{"**/*.go"},
-		},
-	)
+	rule := domain.NewRuleItem("test-package", "test-preset", "test-rule", "# Test Rule\nThis is a test rule.", domain.RuleMetadata{
+		Description: "Test Rule Description",
+		Attach:      domain.AttachTypeAlways,
+		Globs:       []string{"**/*.go"},
+	})
 
 	// Execute
 	serialized, err := adapter.SerializeRule(rule)
@@ -46,15 +40,9 @@ func TestGitHubCopilotAdapter_SerializeRule(t *testing.T) {
 func TestGitHubCopilotAdapter_SerializePrompt(t *testing.T) {
 	// Setup
 	adapter := integration.NewGitHubCopilotAdapter()
-	prompt := domain.NewPromptItem(
-		"test-package",
-		"test-preset",
-		"test-prompt",
-		"# Test Prompt\nThis is a test prompt.",
-		domain.PromptMetadata{
-			Description: "Test Prompt Description",
-		},
-	)
+	prompt := domain.NewPromptItem("test-package", "test-preset", "test-prompt", "# Test Prompt\nThis is a test prompt.", domain.PromptMetadata{
+		Description: "Test Prompt Description",
+	})
 
 	// Execute
 	serialized, err := adapter.SerializePrompt(prompt)

--- a/internal/integration/github-copilot_test.go
+++ b/internal/integration/github-copilot_test.go
@@ -22,13 +22,7 @@ func TestGitHubCopilotAdapter_SerializeRule(t *testing.T) {
 	// Setup
 	adapter := integration.NewGitHubCopilotAdapter()
 	rule := domain.NewRuleItem(
-		domain.URI{
-			Scheme:  domain.Scheme,
-			Package: "test-package",
-			Preset:  "test-preset",
-			Type:    domain.RulesPresetType,
-			Path:    "test-rule",
-		},
+		makeTestURI("test-preset", "test-rule", domain.RulesPresetType),
 		"# Test Rule\nThis is a test rule.",
 		domain.RuleMetadata{
 			Description: "Test Rule Description",
@@ -51,13 +45,7 @@ func TestGitHubCopilotAdapter_SerializePrompt(t *testing.T) {
 	// Setup
 	adapter := integration.NewGitHubCopilotAdapter()
 	prompt := domain.NewPromptItem(
-		domain.URI{
-			Scheme:  domain.Scheme,
-			Package: "test-package",
-			Preset:  "test-preset",
-			Type:    domain.PromptsPresetType,
-			Path:    "test-prompt",
-		},
+		makeTestURI("test-preset", "test-prompt", domain.PromptsPresetType),
 		"# Test Prompt\nThis is a test prompt.",
 		domain.PromptMetadata{
 			Description: "Test Prompt Description",

--- a/internal/integration/integration.go
+++ b/internal/integration/integration.go
@@ -81,14 +81,14 @@ func (repo *integrationImpl) WritePackage(namespace string, pkg *domain.AgentPre
 
 //gocognit:ignore
 func (repo *integrationImpl) writePreset(namespace string, packageName string, preset *domain.AgentPreset) error {
-	resolveRulePath := func(rule *domain.RuleItem) (string, error) {
+	resolveRulePath := func(rule *domain.RuleItem) string {
 		rulePath := rule.URI.GetInternalPath(repo.adapter.RuleExtension())
-		return filepath.Join(repo.resolvedRulesRootDir, namespace, rulePath), nil
+		return filepath.Join(repo.resolvedRulesRootDir, namespace, rulePath)
 	}
 
-	resolvePromptPath := func(prompt *domain.PromptItem) (string, error) {
+	resolvePromptPath := func(prompt *domain.PromptItem) string {
 		promptPath := prompt.URI.GetInternalPath(repo.adapter.PromptExtension())
-		return filepath.Join(repo.resolvedPromptsRootDir, namespace, promptPath), nil
+		return filepath.Join(repo.resolvedPromptsRootDir, namespace, promptPath)
 	}
 
 	eg := errgroup.Group{}

--- a/internal/integration/integration.go
+++ b/internal/integration/integration.go
@@ -81,14 +81,14 @@ func (repo *integrationImpl) WritePackage(namespace string, pkg *domain.AgentPre
 
 //gocognit:ignore
 func (repo *integrationImpl) writePreset(namespace string, packageName string, preset *domain.AgentPreset) error {
-	resolveRulePath := func(rule *domain.RuleItem) string {
+	resolveRulePath := func(rule *domain.RuleItem) (string, error) {
 		rulePath := rule.URI.GetInternalPath(repo.adapter.RuleExtension())
-		return filepath.Join(repo.resolvedRulesRootDir, namespace, rulePath)
+		return filepath.Join(repo.resolvedRulesRootDir, namespace, rulePath), nil
 	}
 
-	resolvePromptPath := func(prompt *domain.PromptItem) string {
+	resolvePromptPath := func(prompt *domain.PromptItem) (string, error) {
 		promptPath := prompt.URI.GetInternalPath(repo.adapter.PromptExtension())
-		return filepath.Join(repo.resolvedPromptsRootDir, namespace, promptPath)
+		return filepath.Join(repo.resolvedPromptsRootDir, namespace, promptPath), nil
 	}
 
 	eg := errgroup.Group{}

--- a/internal/integration/integration.go
+++ b/internal/integration/integration.go
@@ -72,7 +72,7 @@ func (repo *integrationImpl) WritePackage(namespace string, pkg *domain.AgentPre
 
 	for _, preset := range pkg.Presets {
 		eg.Go(func() error {
-			return repo.writePreset(namespace, pkg.PackageName, preset)
+			return repo.writePreset(namespace, preset)
 		})
 	}
 
@@ -80,7 +80,7 @@ func (repo *integrationImpl) WritePackage(namespace string, pkg *domain.AgentPre
 }
 
 //gocognit:ignore
-func (repo *integrationImpl) writePreset(namespace string, packageName string, preset *domain.AgentPreset) error {
+func (repo *integrationImpl) writePreset(namespace string, preset *domain.AgentPreset) error {
 	resolveRulePath := func(rule *domain.RuleItem) string {
 		rulePath := rule.URI.GetInternalPath(repo.adapter.RuleExtension())
 		return filepath.Join(repo.resolvedRulesRootDir, namespace, rulePath)
@@ -104,10 +104,9 @@ func (repo *integrationImpl) writePreset(namespace string, packageName string, p
 
 			if dirErr := utils.EnsureDir(filepath.Dir(rulePath)); dirErr != nil {
 				return fmt.Errorf(
-					"could not ensure dir for rule %s in preset %s, package %s: %w",
+					"could not ensure dir for rule %s (URI: %s): %w",
 					rulePath,
-					preset.Name,
-					packageName,
+					rule.URI.String(),
 					dirErr,
 				)
 			}
@@ -127,10 +126,9 @@ func (repo *integrationImpl) writePreset(namespace string, packageName string, p
 
 			if dirErr := utils.EnsureDir(filepath.Dir(promptPath)); dirErr != nil {
 				return fmt.Errorf(
-					"could not ensure dir for prompt %s in preset %s, package %s: %w",
+					"could not ensure dir for prompt %s (URI: %s): %w",
 					promptPath,
-					preset.Name,
-					packageName,
+					prompt.URI.String(),
 					dirErr,
 				)
 			}

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -65,13 +65,25 @@ func TestWritePreset(t *testing.T) {
 	preset := domain.AgentPreset{
 		Name: "test-preset",
 		Rules: []*domain.RuleItem{
-			domain.NewRuleItem("test-package", "test-preset", "test-rule", "Rule content", domain.RuleMetadata{
+			domain.NewRuleItem(domain.URI{
+				Scheme:  domain.Scheme,
+				Package: "test-package",
+				Preset:  "test-preset",
+				Type:    domain.RulesPresetType,
+				Path:    "test-rule",
+			}, "Rule content", domain.RuleMetadata{
 				Description: "Test rule",
 				Attach:      domain.AttachTypeAlways,
 			}),
 		},
 		Prompts: []*domain.PromptItem{
-			domain.NewPromptItem("test-package", "test-preset", "test-prompt", "Prompt content", domain.PromptMetadata{
+			domain.NewPromptItem(domain.URI{
+				Scheme:  domain.Scheme,
+				Package: "test-package",
+				Preset:  "test-preset",
+				Type:    domain.PromptsPresetType,
+				Path:    "test-prompt",
+			}, "Prompt content", domain.PromptMetadata{
 				Description: "Test prompt",
 			}),
 		},

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -65,27 +65,19 @@ func TestWritePreset(t *testing.T) {
 	preset := domain.AgentPreset{
 		Name: "test-preset",
 		Rules: []*domain.RuleItem{
-			domain.NewRuleItem(domain.URI{
-				Scheme:  domain.Scheme,
-				Package: "test-package",
-				Preset:  "test-preset",
-				Type:    domain.RulesPresetType,
-				Path:    "test-rule",
-			}, "Rule content", domain.RuleMetadata{
-				Description: "Test rule",
-				Attach:      domain.AttachTypeAlways,
-			}),
+			domain.NewRuleItem(
+				makeTestURI("test-rule", domain.RulesPresetType),
+				"Rule content", domain.RuleMetadata{
+					Description: "Test rule",
+					Attach:      domain.AttachTypeAlways,
+				}),
 		},
 		Prompts: []*domain.PromptItem{
-			domain.NewPromptItem(domain.URI{
-				Scheme:  domain.Scheme,
-				Package: "test-package",
-				Preset:  "test-preset",
-				Type:    domain.PromptsPresetType,
-				Path:    "test-prompt",
-			}, "Prompt content", domain.PromptMetadata{
-				Description: "Test prompt",
-			}),
+			domain.NewPromptItem(
+				makeTestURI("test-prompt", domain.PromptsPresetType),
+				"Prompt content", domain.PromptMetadata{
+					Description: "Test prompt",
+				}),
 		},
 	}
 
@@ -226,3 +218,8 @@ func TestEnsureGitignoreFiles(t *testing.T) {
 	_, err = os.Stat(promptsNamespaceDir)
 	require.NoError(t, err, "Prompts namespace directory should exist")
 }
+
+// Note: Directory creation failure tests would require complex mocking of the filesystem
+// which would significantly complicate the test setup. The error paths for utils.EnsureDir
+// failures are covered by the utils package tests and the error handling logic is
+// straightforward - it wraps the error with context and returns it.

--- a/internal/integration/testhelpers_test.go
+++ b/internal/integration/testhelpers_test.go
@@ -6,8 +6,8 @@ import "github.com/sushichan044/ajisai/internal/domain"
 func makeTestURI(path string, itemType domain.PresetType) domain.URI {
 	return domain.URI{
 		Scheme:  domain.Scheme,
-		Package: "test-package", // テストでは常に固定値
-		Preset:  "test-preset",  // テストでは常に固定値
+		Package: "test-package", // Fixed value for tests
+		Preset:  "test-preset",  // Fixed value for tests
 		Type:    itemType,
 		Path:    path,
 	}

--- a/internal/integration/testhelpers_test.go
+++ b/internal/integration/testhelpers_test.go
@@ -1,0 +1,14 @@
+package integration_test
+
+import "github.com/sushichan044/ajisai/internal/domain"
+
+// makeTestURI creates a test URI for use in test cases.
+func makeTestURI(path string, itemType domain.PresetType) domain.URI {
+	return domain.URI{
+		Scheme:  domain.Scheme,
+		Package: "test-package", // テストでは常に固定値
+		Preset:  "test-preset",  // テストでは常に固定値
+		Type:    itemType,
+		Path:    path,
+	}
+}

--- a/internal/integration/windsurf_test.go
+++ b/internal/integration/windsurf_test.go
@@ -22,7 +22,7 @@ func TestWindsurfAdapter_SerializeRule(t *testing.T) {
 	// Setup
 	adapter := integration.NewWindsurfAdapter()
 	rule := domain.NewRuleItem(
-		makeTestURI("test-preset", "test-rule", domain.RulesPresetType),
+		makeTestURI("test-rule", domain.RulesPresetType),
 		"# Test Rule\nThis is a test rule.",
 		domain.RuleMetadata{
 			Description: "Test Rule Description",
@@ -45,7 +45,7 @@ func TestWindsurfAdapter_SerializePrompt(t *testing.T) {
 	// Setup
 	adapter := integration.NewWindsurfAdapter()
 	prompt := domain.NewPromptItem(
-		makeTestURI("test-preset", "test-prompt", domain.PromptsPresetType),
+		makeTestURI("test-prompt", domain.PromptsPresetType),
 		"# Test Prompt\nThis is a test prompt.",
 		domain.PromptMetadata{
 			Description: "Test Prompt Description",

--- a/internal/integration/windsurf_test.go
+++ b/internal/integration/windsurf_test.go
@@ -22,13 +22,7 @@ func TestWindsurfAdapter_SerializeRule(t *testing.T) {
 	// Setup
 	adapter := integration.NewWindsurfAdapter()
 	rule := domain.NewRuleItem(
-		domain.URI{
-			Scheme:  domain.Scheme,
-			Package: "test-package",
-			Preset:  "test-preset",
-			Type:    domain.RulesPresetType,
-			Path:    "test-rule",
-		},
+		makeTestURI("test-preset", "test-rule", domain.RulesPresetType),
 		"# Test Rule\nThis is a test rule.",
 		domain.RuleMetadata{
 			Description: "Test Rule Description",
@@ -51,13 +45,7 @@ func TestWindsurfAdapter_SerializePrompt(t *testing.T) {
 	// Setup
 	adapter := integration.NewWindsurfAdapter()
 	prompt := domain.NewPromptItem(
-		domain.URI{
-			Scheme:  domain.Scheme,
-			Package: "test-package",
-			Preset:  "test-preset",
-			Type:    domain.PromptsPresetType,
-			Path:    "test-prompt",
-		},
+		makeTestURI("test-preset", "test-prompt", domain.PromptsPresetType),
 		"# Test Prompt\nThis is a test prompt.",
 		domain.PromptMetadata{
 			Description: "Test Prompt Description",

--- a/internal/integration/windsurf_test.go
+++ b/internal/integration/windsurf_test.go
@@ -21,17 +21,11 @@ func TestWindsurfAdapter_NewWindsurfAdapter(t *testing.T) {
 func TestWindsurfAdapter_SerializeRule(t *testing.T) {
 	// Setup
 	adapter := integration.NewWindsurfAdapter()
-	rule := domain.NewRuleItem(
-		"test-package",
-		"test-preset",
-		"test-rule",
-		"# Test Rule\nThis is a test rule.",
-		domain.RuleMetadata{
-			Description: "Test Rule Description",
-			Attach:      domain.AttachTypeAlways,
-			Globs:       []string{"**/*.go"},
-		},
-	)
+	rule := domain.NewRuleItem("test-package", "test-preset", "test-rule", "# Test Rule\nThis is a test rule.", domain.RuleMetadata{
+		Description: "Test Rule Description",
+		Attach:      domain.AttachTypeAlways,
+		Globs:       []string{"**/*.go"},
+	})
 
 	// Execute
 	serialized, err := adapter.SerializeRule(rule)
@@ -46,15 +40,9 @@ func TestWindsurfAdapter_SerializeRule(t *testing.T) {
 func TestWindsurfAdapter_SerializePrompt(t *testing.T) {
 	// Setup
 	adapter := integration.NewWindsurfAdapter()
-	prompt := domain.NewPromptItem(
-		"test-package",
-		"test-preset",
-		"test-prompt",
-		"# Test Prompt\nThis is a test prompt.",
-		domain.PromptMetadata{
-			Description: "Test Prompt Description",
-		},
-	)
+	prompt := domain.NewPromptItem("test-package", "test-preset", "test-prompt", "# Test Prompt\nThis is a test prompt.", domain.PromptMetadata{
+		Description: "Test Prompt Description",
+	})
 
 	// Execute
 	serialized, err := adapter.SerializePrompt(prompt)

--- a/internal/integration/windsurf_test.go
+++ b/internal/integration/windsurf_test.go
@@ -21,11 +21,17 @@ func TestWindsurfAdapter_NewWindsurfAdapter(t *testing.T) {
 func TestWindsurfAdapter_SerializeRule(t *testing.T) {
 	// Setup
 	adapter := integration.NewWindsurfAdapter()
-	rule := domain.NewRuleItem("test-package", "test-preset", "test-rule", "# Test Rule\nThis is a test rule.", domain.RuleMetadata{
-		Description: "Test Rule Description",
-		Attach:      domain.AttachTypeAlways,
-		Globs:       []string{"**/*.go"},
-	})
+	rule := domain.NewRuleItem(
+		"test-package",
+		"test-preset",
+		"test-rule",
+		"# Test Rule\nThis is a test rule.",
+		domain.RuleMetadata{
+			Description: "Test Rule Description",
+			Attach:      domain.AttachTypeAlways,
+			Globs:       []string{"**/*.go"},
+		},
+	)
 
 	// Execute
 	serialized, err := adapter.SerializeRule(rule)
@@ -40,9 +46,15 @@ func TestWindsurfAdapter_SerializeRule(t *testing.T) {
 func TestWindsurfAdapter_SerializePrompt(t *testing.T) {
 	// Setup
 	adapter := integration.NewWindsurfAdapter()
-	prompt := domain.NewPromptItem("test-package", "test-preset", "test-prompt", "# Test Prompt\nThis is a test prompt.", domain.PromptMetadata{
-		Description: "Test Prompt Description",
-	})
+	prompt := domain.NewPromptItem(
+		"test-package",
+		"test-preset",
+		"test-prompt",
+		"# Test Prompt\nThis is a test prompt.",
+		domain.PromptMetadata{
+			Description: "Test Prompt Description",
+		},
+	)
 
 	// Execute
 	serialized, err := adapter.SerializePrompt(prompt)

--- a/internal/integration/windsurf_test.go
+++ b/internal/integration/windsurf_test.go
@@ -22,9 +22,13 @@ func TestWindsurfAdapter_SerializeRule(t *testing.T) {
 	// Setup
 	adapter := integration.NewWindsurfAdapter()
 	rule := domain.NewRuleItem(
-		"test-package",
-		"test-preset",
-		"test-rule",
+		domain.URI{
+			Scheme:  domain.Scheme,
+			Package: "test-package",
+			Preset:  "test-preset",
+			Type:    domain.RulesPresetType,
+			Path:    "test-rule",
+		},
 		"# Test Rule\nThis is a test rule.",
 		domain.RuleMetadata{
 			Description: "Test Rule Description",
@@ -47,9 +51,13 @@ func TestWindsurfAdapter_SerializePrompt(t *testing.T) {
 	// Setup
 	adapter := integration.NewWindsurfAdapter()
 	prompt := domain.NewPromptItem(
-		"test-package",
-		"test-preset",
-		"test-prompt",
+		domain.URI{
+			Scheme:  domain.Scheme,
+			Package: "test-package",
+			Preset:  "test-preset",
+			Type:    domain.PromptsPresetType,
+			Path:    "test-prompt",
+		},
 		"# Test Prompt\nThis is a test prompt.",
 		domain.PromptMetadata{
 			Description: "Test Prompt Description",

--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -184,7 +184,14 @@ func (l *agentPresetLoader) loadPromptItems(
 			return fmt.Errorf("failed to parse prompt markdown %s: %w", fullPath, parseErr)
 		}
 
-		promptItem := domain.NewPromptItem(packageName, presetName, uriPath, result.Content, result.FrontMatter)
+		uri := domain.URI{
+			Scheme:  domain.Scheme,
+			Package: packageName,
+			Preset:  presetName,
+			Type:    domain.PromptsPresetType,
+			Path:    uriPath,
+		}
+		promptItem := domain.NewPromptItem(uri, result.Content, result.FrontMatter)
 		loadedPrompts = append(loadedPrompts, promptItem)
 		return nil
 	})
@@ -227,7 +234,14 @@ func (l *agentPresetLoader) loadRuleItems(
 			return fmt.Errorf("failed to parse rule markdown %s: %w", fullPath, parseErr)
 		}
 
-		ruleItem := domain.NewRuleItem(packageName, presetName, uriPath, result.Content, result.FrontMatter)
+		uri := domain.URI{
+			Scheme:  domain.Scheme,
+			Package: packageName,
+			Preset:  presetName,
+			Type:    domain.RulesPresetType,
+			Path:    uriPath,
+		}
+		ruleItem := domain.NewRuleItem(uri, result.Content, result.FrontMatter)
 		loadedRules = append(loadedRules, ruleItem)
 		return nil
 	})

--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -184,13 +184,7 @@ func (l *agentPresetLoader) loadPromptItems(
 			return fmt.Errorf("failed to parse prompt markdown %s: %w", fullPath, parseErr)
 		}
 
-		uri := domain.URI{
-			Scheme:  domain.Scheme,
-			Package: packageName,
-			Preset:  presetName,
-			Type:    domain.PromptsPresetType,
-			Path:    uriPath,
-		}
+		uri := makeItemURI(packageName, presetName, uriPath, domain.PromptsPresetType)
 		promptItem := domain.NewPromptItem(uri, result.Content, result.FrontMatter)
 		loadedPrompts = append(loadedPrompts, promptItem)
 		return nil
@@ -200,6 +194,17 @@ func (l *agentPresetLoader) loadPromptItems(
 		return nil, err
 	}
 	return loadedPrompts, nil
+}
+
+// makeItemURI creates a URI for a rule or prompt item with the given parameters.
+func makeItemURI(packageName, presetName, uriPath string, itemType domain.PresetType) domain.URI {
+	return domain.URI{
+		Scheme:  domain.Scheme,
+		Package: packageName,
+		Preset:  presetName,
+		Type:    itemType,
+		Path:    uriPath,
+	}
 }
 
 func (l *agentPresetLoader) loadRuleItems(
@@ -234,13 +239,7 @@ func (l *agentPresetLoader) loadRuleItems(
 			return fmt.Errorf("failed to parse rule markdown %s: %w", fullPath, parseErr)
 		}
 
-		uri := domain.URI{
-			Scheme:  domain.Scheme,
-			Package: packageName,
-			Preset:  presetName,
-			Type:    domain.RulesPresetType,
-			Path:    uriPath,
-		}
+		uri := makeItemURI(packageName, presetName, uriPath, domain.RulesPresetType)
 		ruleItem := domain.NewRuleItem(uri, result.Content, result.FrontMatter)
 		loadedRules = append(loadedRules, ruleItem)
 		return nil


### PR DESCRIPTION
## Summary

- Remove logging-only parameters from functions that were only used for debugging purposes
- Implement comprehensive URI-based resource identification system  
- Update integration layer to use URI.GetInternalPath() for consistent path handling
- Fix unused error returns in integration helper functions

## Changes

**URI-based Resource Identification:**
- Added URI.GetInternalPath() method for consistent internal path representation
- Updated all integration modules (Cursor, GitHub Copilot, Windsurf) to use URI-based logging
- Enhanced test coverage with URI-based assertions

**Parameter Cleanup:**
- Removed logging-only parameters from bridge functions
- Simplified function signatures while maintaining functionality
- Updated all callers to use the cleaner interface

**Integration Layer Improvements:**
- Fixed unused error returns in helper functions
- Consolidated path handling logic using URI methods
- Improved error handling and resource identification

## Test Plan

- [x] All existing tests pass
- [x] Updated test assertions to use URI-based identification
- [x] Verified integration modules work correctly with new URI system
- [x] Confirmed no regression in functionality

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Standardized creation of rule and prompt items using a unified URI structure, simplifying constructors and internal logic.
  - Updated function signatures to accept a URI object instead of multiple string arguments.
  - Adjusted related test cases and integration logic to use the new URI-based approach consistently.
- **Documentation**
  - Improved code block formatting in documentation for better clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->